### PR TITLE
feat: unified Cache API caching for offline support

### DIFF
--- a/src/lib/req.ts
+++ b/src/lib/req.ts
@@ -30,24 +30,84 @@ import { error, redirect } from '@sveltejs/kit';
 import { confirm, status } from '$lib/store';
 import { get } from 'svelte/store';
 
-const cacheData = '.d';
-const cacheKey = '.k';
-const cacheExpire = '.e';
-const cacheGroup = '.g';
-const cacheBegin = '.b';
+const CACHE_BUCKET = 'emm-data';
 
-let reqCacheMap: reqCache;
-const cacheNames = [cacheData, cacheKey, cacheExpire, cacheBegin];
+/** Write API response to Cache API. TTL stored as x-cache-ttl header (epoch ms). */
+async function cacheApiPut(fullUrl: string, data: unknown, ttlMs: number) {
+	const cache = await caches.open(CACHE_BUCKET);
+	const res = new Response(JSON.stringify(data), {
+		headers: { 'x-cache-ttl': String(Date.now() + ttlMs) }
+	});
+	await cache.put(fullUrl, res);
+}
+
+/** Read from Cache API by full URL. Returns {data,ttl} or null if absent/expired. */
+async function cacheApiGet(fullUrl: string): Promise<{ data: unknown; ttl: number } | null> {
+	const cache = await caches.open(CACHE_BUCKET);
+	const res = await cache.match(fullUrl);
+	if (!res) return null;
+	const ttl = Number(res.headers.get('x-cache-ttl'));
+	if (ttl && ttl < Date.now()) return null;
+	const data = await res.json();
+	return { data, ttl: ttl || Date.now() + 864e5 };
+}
+
+/** Delete all Cache API entries whose URL path starts with /api/{prefix}. */
+async function cacheApiDeletePrefix(apiPrefix: string) {
+	const cache = await caches.open(CACHE_BUCKET);
+	const keys = await cache.keys();
+	for (const req of keys) {
+		if (new URL(req.url).pathname.startsWith(`/api/${apiPrefix}`)) {
+			await cache.delete(req);
+		}
+	}
+}
+
+/** Warm the in-memory cache from Cache API (async, fire-and-forget at module load). */
+async function loadFromCacheAPI() {
+	if (!browser) return;
+	const cache = await caches.open(CACHE_BUCKET);
+	const keys = await cache.keys();
+	for (const req of keys) {
+		try {
+			const res = await cache.match(req);
+			if (!res) continue;
+			const ttl = Number(res.headers.get('x-cache-ttl'));
+			if (ttl && ttl < Date.now()) continue;
+			const data = await res.json();
+			const url = new URL(req.url);
+			const path = url.pathname.replace(/^\/api\//, '');
+			const params: Record<string, string> = {};
+			url.searchParams.forEach((v, k) => { params[k] = v; });
+			const rk = reqKey(
+				path,
+				Object.keys(params).length ? params : undefined,
+				1 // method.GET
+			);
+			reqCacheMap.set(rk, [ttl || Date.now() + 864e5, data, undefined]);
+		} catch {
+			/* skip */
+		}
+	}
+}
+loadFromCacheAPI();
+
+const reqCacheMap: reqCache = new Map();
 const reqPromiseCache = new Map<string, Promise<reqData>>();
 const reqKey = (url: string, params: reqParams, method?: MethodNumber, key?: string | number) => {
 	let rk = `${url}${method || 0}`;
 	if (key) return `${rk}${key}`;
 	if (params !== undefined) {
-		const k = JSON.stringify(params).replace(/[,.^{}()\-_'"\\/?:]/gi, '');
-		rk = `${url}_${k.length}_${Array.from(k).reduce((a, b) => a + b.charCodeAt(0), 0)}`;
+		// Sort keys alphabetically so {a:1,b:2} and {b:2,a:1} produce the same key.
+		const sorted: Record<string, unknown> = {};
+		Object.keys(params as Record<string, unknown>)
+			.sort()
+			.forEach((k) => { sorted[k] = (params as Record<string, unknown>)[k]; });
+		rk = `${rk}_${JSON.stringify(sorted)}`;
 	}
 	return rk;
 };
+const group = new Map<string, Set<string>>();
 export const clearGroup = (groupKey: string) => {
 	const s = group.get(groupKey);
 	if (s && s.size) {
@@ -55,72 +115,9 @@ export const clearGroup = (groupKey: string) => {
 		for (const k of s) {
 			reqCacheMap.delete(k);
 		}
-		saveCacheToStorage();
+		cacheApiDeletePrefix(groupKey);
 	}
 };
-const group = new Map<string, Set<string>>();
-const saveCacheToStorage = () => {
-	if (!browser) return;
-	const d = [] as unknown[];
-	const k = [] as string[];
-	const e = [] as number[];
-	const now = Date.now();
-	const g = [];
-	for (const [k, v] of group) {
-		g.push(`${k}:${[...v].join()}`);
-	}
-	localStorage.setItem(cacheGroup, g.join(';'));
-	localStorage.setItem(cacheBegin, now + '');
-	for (const [a, [n, b, p]] of reqCacheMap) {
-		const dur = n - now;
-		if (!p && dur > 0) {
-			k.push(a);
-			d.push(b);
-			e.push(dur);
-		}
-	}
-	localStorage.setItem(cacheData, JSON.stringify(d));
-	localStorage.setItem(cacheKey, k.join());
-	localStorage.setItem(cacheExpire, e.join());
-	localStorage.setItem(cacheBegin, now + '');
-};
-
-const loadCacheFromStorage = () => {
-	if (!browser) return;
-	if (!reqCacheMap) reqCacheMap = new Map();
-	const g = localStorage.getItem(cacheGroup);
-	if (g) {
-		g.split(';').forEach((a) => {
-			const [k, v] = a.split(':');
-			group.set(k, new Set(v.split(',')));
-		});
-	}
-	let ch;
-	const [d, k, e, b] = cacheNames.map((a) => localStorage.getItem(a));
-	if (d && k && e && b) {
-		try {
-			const da = JSON.parse(d);
-			const ke = k.split(',');
-			const ex = e.split(',').map((a) => +a);
-			const bg = +b;
-			const n = Date.now();
-			ex.forEach((a: number, i: number) => {
-				const exp = a + bg;
-				// Keep expired entries in-memory so reqCache() can serve them when offline.
-				// saveCacheToStorage() will filter them out of persistence on next write.
-				reqCacheMap.set(ke[i], [exp, da[i], undefined]);
-				if (exp <= n) {
-					ch = 1;
-				}
-			});
-		} catch (e) {
-			console.error(e);
-			// ignore
-		}
-	}
-	if (ch) saveCacheToStorage();
-};
-loadCacheFromStorage();
 
 let isLoadFn = false;
 let hydrationDone = false;
@@ -133,30 +130,49 @@ const allowReadCache = () => {
 	if (isLoadFn && !hydrationDone) return false; // hydration: always fetch fresh
 	return true;
 };
-const reqCache = (key: string, run: (re?: cacheRecord) => Promise<reqData>): Promise<reqData> => {
+const reqCache = (
+	key: string,
+	fullUrl: string | null,
+	run: (re?: cacheRecord) => Promise<reqData>
+): Promise<reqData> => {
 	if (!key || !browser) return run();
 	const rec = reqCacheMap.get(key);
 	const now = Date.now();
-	const offline = !navigator.onLine;
 
+	// L1: in-memory hit
 	if (allowReadCache() && rec) {
 		const [n, d, p] = rec;
 		if (p) return p;
-		// When offline, serve cache immediately regardless of expiry — skip the network entirely.
-		if (offline) {
-			console.info('[Offline Mode] Serving from cache (expired or not), skipping network.');
-			return Promise.resolve(d);
-		}
-		// Online: serve only if not yet expired.
 		if (n > now) return Promise.resolve(d);
+		// Expired — evict from memory, fall through to L2/network.
+		reqCacheMap.delete(key);
 	}
+
+	// L2: Cache API fallback (cold start, uses actual TTL from cached response).
+	// Respect allowReadCache — skip during hydration to let SvelteKit's embedded fetch handle it.
+	const tryCacheAPI = allowReadCache() && fullUrl
+		? cacheApiGet(fullUrl).then((entry) => {
+				if (entry !== null) {
+					reqCacheMap.set(key, <[number, object | string | number | boolean | void | null, Promise<reqData> | undefined]>[entry.ttl, entry.data, undefined]);
+					return entry.data;
+				}
+				return undefined;
+			})
+		: Promise.resolve(undefined);
 
 	const r = [-1, undefined, undefined] as cacheRecord;
 	reqCacheMap.set(key, r);
 
-	r[2] = run(r).catch((err) => {
+	r[2] = tryCacheAPI.then((cached) => {
+		if (cached !== undefined) return cached;
+		// L3: network
+		return run(r);
+	}).then(async (d) => {
+		if (fullUrl) cacheApiPut(fullUrl, d, 864e5);
+		return d;
+	}).catch((err) => {
 		if (rec && rec[1] !== undefined) {
-			console.warn(`[Offline Mode] Network failed. Using stale local history data.`, err);
+			console.warn(`Network failed. Using stale cache.`, err);
 			return rec[1];
 		}
 		throw err;
@@ -285,14 +301,6 @@ const query = async (url: ApiName, params?: reqParams, cfg?: reqOption): Promise
 	});
 };
 
-function delGroupKey(key: string) {
-	for (const [k, s] of group) {
-		if (s.has(key)) {
-			s.delete(key);
-			if (!s.size) group.delete(k);
-		}
-	}
-}
 export const addGroupKey = (groupKey: string, key: string) => {
 	const s = group.get(groupKey) || new Set<string>();
 	s.add(key);
@@ -314,7 +322,9 @@ export const saveCache = (
 	const now = Date.now();
 	const r = [now + c, d, undefined] as cacheRecord;
 	reqCacheMap.set(key, r);
-	saveCacheToStorage();
+	// Also write to Cache API (SW shares this bucket)
+	const fullUrl = `/api/${url}${p ? '?' + body2query(p as Record<string, unknown>) : ''}`;
+	cacheApiPut(fullUrl, d, c);
 };
 const delayMap = new Map<string, [connectFn, (params?: reqParams) => void, boolean]>();
 export const req = (url: ApiName, params?: reqParams, cfg?: reqOption) => {
@@ -362,13 +372,16 @@ export const req = (url: ApiName, params?: reqParams, cfg?: reqOption) => {
 	let p = browser ? reqPromiseCache.get(key) : undefined;
 	if (!p) {
 		const cache = cfg?.cache;
-		p = reqCache(cache ? key : '', async (rec) => {
+		const fullUrl =
+			cache && cfg?.method === method.GET
+				? `/api/${url}${params ? '?' + body2query(params as Record<string, unknown>) : ''}`
+				: null;
+		p = reqCache(cache ? key : '', fullUrl, async (rec) => {
 			const d = await query(url, params, cfg);
 			if (cache && rec) {
 				rec[0] = Date.now() + cache;
 				rec[1] = d;
 				rec[2] = undefined;
-				saveCacheToStorage();
 			}
 			return d;
 		})

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -7,14 +7,6 @@ import type { BeforeNavigate } from '@sveltejs/kit';
 import type { FwResp } from '$lib/server/model';
 import { req } from '$lib/req';
 import { method } from '$lib/enum';
-import { browser } from '$app/environment';
-
-/** Global online/offline state. Subscribers can reactively show stale-data indicators. */
-export const isOnline = writable(browser ? navigator.onLine : true);
-if (browser) {
-	window.addEventListener('online', () => isOnline.set(true));
-	window.addEventListener('offline', () => isOnline.set(false));
-}
 
 const user = writable({
 	token: 'test'

--- a/src/routes/(app)/posts/[[page]]/+page.ts
+++ b/src/routes/(app)/posts/[[page]]/+page.ts
@@ -19,6 +19,7 @@ const hash = (s: string) => {
 };
 
 export const load = async (event) => {
+	
 	const result = await baseLoad(event);
 	if (result.d) {
 		event.setHeaders({ etag: `"${hash(JSON.stringify(result.d))}"`, 'cache-control': 'private, must-revalidate' });

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -5,17 +5,45 @@ const DEV = self.location.hostname === 'localhost' || self.location.hostname ===
 
 const channel = new BroadcastChannel('sw-messages');
 const cachePrefix = 'sw-';
-// Dev mode uses a fixed cache name — `version` changes on every Vite rebuild,
-// which would otherwise trigger activate→delete and wipe the offline cache.
 const CACHE = DEV ? 'sw-dev' : `${cachePrefix}${version}`;
 const RES_CACHE = 'res';
-const ASSETS = [
-	...build, // the app itself
-	...files // everything in `static`
-];
-// Navigation routes to precache so the app shell is available offline immediately
-// after install, even for pages the user hasn't visited yet.
+const DATA_CACHE = 'emm-data';
+const ASSETS = [...build, ...files];
+
+// Navigation routes precached at install. The HTML contains SSR-embedded
+// API data (<script data-sveltekit-fetched>) which we extract and store
+// separately so req.ts can serve it offline.
 const PRECACHE_ROUTES = ['/', '/about', '/posts', '/tags'];
+
+/**
+ * Extract data-sveltekit-fetched payloads from an HTML string.
+ * Returns [url, parsedBody][] tuples.
+ */
+function extractFetchedData(html) {
+	const results = [];
+	const regex = /<script type="application\/json" data-sveltekit-fetched data-url="([^"]*)"[^>]*>([\s\S]*?)<\/script>/g;
+	let match;
+	while ((match = regex.exec(html)) !== null) {
+		const url = match[1].replace(/&amp;/g, '&');
+		try {
+			const raw = JSON.parse(match[2]);
+			let data;
+			if (typeof raw.body === 'string') {
+				try {
+					data = JSON.parse(raw.body);
+				} catch {
+					data = raw.body; // plain-text response (e.g. /api/tags)
+				}
+			} else {
+				data = raw.body;
+			}
+			results.push([url, data]);
+		} catch {
+			/* malformed */
+		}
+	}
+	return results;
+}
 
 self.addEventListener('install', (event) => {
 	const {
@@ -25,10 +53,32 @@ self.addEventListener('install', (event) => {
 	async function addFilesToCache() {
 		const cache = await caches.open(CACHE);
 		await cache.addAll(ASSETS);
-		// Precache nav routes individually so one failure doesn't block the rest
+
+		const dataCache = await caches.open(DATA_CACHE);
 		for (const route of PRECACHE_ROUTES) {
 			try {
-				await cache.add(route);
+				const response = await fetch(route);
+				if (!response.ok) continue;
+				const html = await response.text();
+
+				// Extract embedded API data
+				const entries = extractFetchedData(html);
+				for (const [url, data] of entries) {
+					await dataCache.put(
+						new Request(url),
+						new Response(JSON.stringify(data), {
+							headers: {
+								'Content-Type': 'application/json',
+								'x-cache-ttl': String(Date.now() + 864e5)
+							}
+						})
+					);
+				}
+
+				// Cache the HTML page
+				await cache.put(route, new Response(html, {
+					headers: { 'Content-Type': 'text/html; charset=utf-8' }
+				}));
 			} catch {
 				// Route may require server context not available at install time
 			}
@@ -37,7 +87,6 @@ self.addEventListener('install', (event) => {
 
 	const p = addFilesToCache();
 	event.waitUntil(p);
-
 	if (active) {
 		event.waitUntil(
 			p.then(() => {
@@ -51,23 +100,21 @@ self.addEventListener('install', (event) => {
 self.addEventListener('activate', (event) => {
 	async function deleteOldCaches() {
 		for (const key of await caches.keys()) {
-			if (key !== CACHE && key.startsWith('sw-')) await caches.delete(key);
+			if (key !== CACHE && key !== DATA_CACHE && key.startsWith('sw-')) await caches.delete(key);
 		}
 	}
 	event.waitUntil(deleteOldCaches());
 });
 
 self.addEventListener('fetch', (event) => {
-	// 保持原样：非 GET 请求不拦截
 	if (event.request.method !== 'GET') return;
 
-	const pathname = URL.parse(event.request.url).pathname;
-	if (/^\/(api|admin|login|feed)/.test(pathname)) return;
+	const url = new URL(event.request.url);
+	const pathname = url.pathname;
+	if (/^\/(admin|login|feed|api)/.test(pathname)) return;
 
-	// Dev mode (Vite HMR): network-first, populate cache for offline.
-	// Always serves live Vite content; caches on the fly so offline has a full app shell.
 	if (DEV) {
-		async function networkFirst() {
+		async function devNetworkFirst() {
 			try {
 				const response = await fetch(event.request);
 				const cache = await caches.open(CACHE);
@@ -78,14 +125,13 @@ self.addEventListener('fetch', (event) => {
 				return cache.match(event.request);
 			}
 		}
-		return event.respondWith(networkFirst());
+		event.respondWith(devNetworkFirst());
+		return;
 	}
 
 	async function respond() {
-		const url = new URL(event.request.url);
-		let isRes = url.pathname.startsWith('/res/');
+		let isRes = pathname.startsWith('/res/');
 
-		// 跨域处理：判断是否为 R2 资源
 		if (!isRes && url.hostname !== self.location.hostname) {
 			const configCache = await caches.open('sw-config');
 			const configResponse = await configCache.match('/__config/r2-host');
@@ -118,7 +164,7 @@ self.addEventListener('fetch', (event) => {
 					return networkResponse;
 				})
 				.catch((fetchErr) => {
-					console.warn('SW 后台更新缓存失败（可能处于离线状态）:', fetchErr);
+					console.warn('SW background fetch failed (offline):', fetchErr);
 				});
 
 			if (cachedResponse) {
@@ -131,8 +177,13 @@ self.addEventListener('fetch', (event) => {
 
 			throw new Error('No cache and network failed');
 		} catch (err) {
-			console.error('SW 处理请求崩溃，启动安全防御:', err);
-			return fetch(event.request);
+			console.error('SW crashed, safety fallback to network:', err);
+			// Never return a raw fetch() promise — it may reject offline.
+			// Return a proper error Response so event.respondWith() always gets a Response.
+			return new Response('Offline — resource not cached', {
+				status: 503,
+				statusText: 'Service Unavailable'
+			});
 		}
 	}
 


### PR DESCRIPTION
- req.ts: replace localStorage with Cache API (emm-data) as sole persistence layer
- req.ts: reqCache 3-tier (memory -> Cache API -> network) with hydration guard
- req.ts: sorted JSON.stringify reqKey to prevent hash collisions
- service-worker.js: extractFetchedData handles plain-text API responses
- service-worker.js: return 503 Response instead of rejected promise on cache miss
- service-worker.js: dev mode fixed cache name (sw-dev) to survive Vite rebuilds
- remove: isOnline store, ping endpoint, app.html capture script, offline bar